### PR TITLE
Fix improper scrolldown button display issue.

### DIFF
--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -160,8 +160,8 @@ module.exports = React.createClass({
     // content. So don't call it in render() cycles.
     isAtBottom: function() {
         var sn = this._getScrollNode();
-        // + 1 here to avoid fractional pixel rounding errors
-        return sn.scrollHeight - sn.scrollTop <= sn.clientHeight + 1;
+        // + 2 here to avoid fractional pixel rounding errors
+        return sn.scrollHeight - sn.scrollTop <= sn.clientHeight + 2;
     },
 
     // check the scroll state and send out backfill requests if necessary.


### PR DESCRIPTION
This fixes an intermittent issue where the scrolldown button
or "new messages below" button would display even when the messages
panel was scrolled to the very bottom. Furthermore, when new messages
arrived, the messages panel would not automatically scroll down to show
the new messages.

Fixes https://github.com/vector-im/vector-web/issues/805
